### PR TITLE
Fix exception after successful message transmit

### DIFF
--- a/websmscom_lib.js
+++ b/websmscom_lib.js
@@ -742,6 +742,7 @@ var events = require('events');
       });
       
       response.on('close', function(e){
+        if (e === undefined) return;
         var errorObj = WebSmsCom.getErrorObj({
           'cause': WebSmsCom.errorCauses.connection,
           'message': 'HTTPS Response close event: ' + e.message,


### PR DESCRIPTION
In our case we get an exception even if the message sending was successful.
I also enabled debug mode and get 200 HTTP responses with status code 2000.
> .../node_modules/websmscom/websmscom_lib.js:748
>           'message': 'HTTPS Response close event: ' + e.message,
>                                                         ^
> TypeError: Cannot read property 'message' of undefined
>     at IncomingMessage.<anonymous> (.../node_modules/websmscom/websmscom_lib.js:748:57)